### PR TITLE
Rope Positions Require Higher Precision

### DIFF
--- a/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/rope.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/rope.py
@@ -55,9 +55,7 @@ class RoPE(torch.nn.Module):
         self, seq_len: int, device: torch.device, dtype: torch.dtype
     ) -> None:
         self.max_seq_len_cached = seq_len
-        t = torch.arange(
-            self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype
-        )
+        t = torch.arange(self.max_seq_len_cached, device=device, dtype=torch.float32)
 
         freqs = torch.outer(t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation


### PR DESCRIPTION
Previously the rope positions were created like this

```python
t = torch.arange(
     self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype
)
```
 
**Problem**

It could happen that `inv_freq` can end up having a low precision dtype:
- even if `inv_freq` was created in float32, it could happen that the model's parameters ended up being downcasted. 
- if so, then it is not reliable to infer the `dtype` of `inv_freq` since that may change from creation time.
- If `inv_freq` was downcasted to `bfloat16`, then it has a limited mantissa, and cannot represent values even up to 3000+, of which `self.max_seq_len_cached` can exceed.

**Fix**
The fix here is to create the `t` vector in `float32` everytime, and not infer the dtype of `inv_freq`.

**Loss Comparisons**

![image](https://github.com/user-attachments/assets/4aed41c0-e2a7-4a87-95ca-241003fedeee)


