### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ on:
       - '.github/**'
 
 env:
-  PYTHON_VERSION: 3.11
+  PYTHON_VERSION: 3.12
 
 jobs:
   lint:
@@ -45,10 +45,10 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml

--- a/src/instructlab/dolomite/hf_models/__init__.py
+++ b/src/instructlab/dolomite/hf_models/__init__.py
@@ -2,9 +2,9 @@
 # Extracted from https://github.com/ibm-granite/dolomite-engine
 # ----------------------------------------------------------------
 # Local
-from .models.gpt_dolomite.config import GPTDolomiteConfig
 from .model_conversion import export_to_huggingface, import_from_huggingface
 from .models import GPTDolomiteForCausalLM, GPTDolomiteModel
+from .models.gpt_dolomite.config import GPTDolomiteConfig
 from .register_hf import register_model_classes
 
 register_model_classes()

--- a/src/instructlab/dolomite/hf_models/config.py
+++ b/src/instructlab/dolomite/hf_models/config.py
@@ -1,5 +1,7 @@
+# Third Party
 from transformers import PretrainedConfig
 
+# Local
 from .enums import AttentionHeadType, InitMethod, PositionEmbeddingType
 
 
@@ -98,7 +100,9 @@ class CommonConfig(PretrainedConfig):
             if self.num_key_value_heads is None:
                 self.num_key_value_heads = 1
 
-            assert self.num_key_value_heads == 1, "MultiQueryAttention should have 1 head for keys and values"
+            assert (
+                self.num_key_value_heads == 1
+            ), "MultiQueryAttention should have 1 head for keys and values"
         elif attention_head_type == AttentionHeadType.gqa:
             assert (
                 self.num_key_value_heads is not None
@@ -108,4 +112,9 @@ class CommonConfig(PretrainedConfig):
                 self.n_head % self.num_key_value_heads == 0
             ), "GroupedQueryAttention should have more than 1 head for keys and values"
 
-        super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, pad_token_id=pad_token_id, **kwargs)
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            pad_token_id=pad_token_id,
+            **kwargs,
+        )

--- a/src/instructlab/dolomite/hf_models/enums.py
+++ b/src/instructlab/dolomite/hf_models/enums.py
@@ -1,3 +1,4 @@
+# Standard
 from enum import Enum
 
 

--- a/src/instructlab/dolomite/hf_models/mixins/__init__.py
+++ b/src/instructlab/dolomite/hf_models/mixins/__init__.py
@@ -1,4 +1,7 @@
+# Local
 from .dense import BaseModelMixin, CausalLMModelMixin, PreTrainedModelMixin
-#from .dense_TP import BaseModelMixin_TP, CausalLMModelMixin_TP, PreTrainedModelMixin_TP
+
+# from .dense_TP import BaseModelMixin_TP, CausalLMModelMixin_TP, PreTrainedModelMixin_TP
 from .moe import BaseMoEModelMixin, CausalLMMoEModelMixin, PreTrainedMoEModelMixin
-#from .moe_TP import BaseMoEModelMixin_TP, CausalLMMoEModelMixin_TP, PreTrainedMoEModelMixin_TP
+
+# from .moe_TP import BaseMoEModelMixin_TP, CausalLMMoEModelMixin_TP, PreTrainedMoEModelMixin_TP

--- a/src/instructlab/dolomite/hf_models/mixins/dense/__init__.py
+++ b/src/instructlab/dolomite/hf_models/mixins/dense/__init__.py
@@ -1,2 +1,3 @@
+# Local
 from .base import BaseModelMixin, PreTrainedModelMixin
 from .main import CausalLMModelMixin

--- a/src/instructlab/dolomite/hf_models/mixins/dense_TP/__init__.py
+++ b/src/instructlab/dolomite/hf_models/mixins/dense_TP/__init__.py
@@ -1,2 +1,3 @@
+# Local
 from .base import BaseModelMixin_TP, PreTrainedModelMixin_TP
 from .main import CausalLMModelMixin_TP

--- a/src/instructlab/dolomite/hf_models/mixins/dense_TP/base.py
+++ b/src/instructlab/dolomite/hf_models/mixins/dense_TP/base.py
@@ -1,16 +1,25 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from ....utils import ProcessGroupManager
 from ...config import CommonConfig
 from ...enums import AttentionHeadType, PositionEmbeddingType
 from ...modeling_utils import RoPE, YaRNScaledRoPE
-from ...modeling_utils_TP import Alibi_TP, Dropout_TP, Embedding_TP, get_normalization_function_TP
+from ...modeling_utils_TP import (
+    Alibi_TP,
+    Dropout_TP,
+    Embedding_TP,
+    get_normalization_function_TP,
+)
 from ..dense import BaseModelMixin, PreTrainedModelMixin
 
 
 class PreTrainedModelMixin_TP(PreTrainedModelMixin):
     def __init__(self, config: CommonConfig, *args, **kwargs):
-        self.tensor_parallel_word_embeddings = kwargs.get("tensor_parallel_word_embeddings", False)
+        self.tensor_parallel_word_embeddings = kwargs.get(
+            "tensor_parallel_word_embeddings", False
+        )
         self.sequence_parallel = kwargs.get("sequence_parallel", False)
 
         super().__init__(config, *args, **kwargs)
@@ -67,7 +76,9 @@ class BaseModelMixin_TP(PreTrainedModelMixin_TP, BaseModelMixin):
             sequence_parallel=self.sequence_parallel,
         )
 
-        self.position_embedding_type = PositionEmbeddingType(config.position_embedding_type)
+        self.position_embedding_type = PositionEmbeddingType(
+            config.position_embedding_type
+        )
         self._setup_positional_encoding()
 
         # Initialize weights and apply final processing
@@ -90,7 +101,9 @@ class BaseModelMixin_TP(PreTrainedModelMixin_TP, BaseModelMixin):
         elif self.position_embedding_type == PositionEmbeddingType.rope:
             if self.config.rope_scaling is None:
                 self.rope = RoPE(
-                    self.head_dim, max_position_embeddings=max_position_embeddings, base=self.config.rope_theta
+                    self.head_dim,
+                    max_position_embeddings=max_position_embeddings,
+                    base=self.config.rope_theta,
                 )
             else:
                 self.rope = YaRNScaledRoPE(
@@ -98,7 +111,9 @@ class BaseModelMixin_TP(PreTrainedModelMixin_TP, BaseModelMixin):
                     max_position_embeddings=max_position_embeddings,
                     base=self.config.rope_theta,
                     scale=self.config.rope_scaling["factor"],
-                    original_max_position_embeddings=self.config.rope_scaling["original_max_position_embeddings"],
+                    original_max_position_embeddings=self.config.rope_scaling[
+                        "original_max_position_embeddings"
+                    ],
                 )
         else:
             raise NotImplementedError()

--- a/src/instructlab/dolomite/hf_models/mixins/moe/__init__.py
+++ b/src/instructlab/dolomite/hf_models/mixins/moe/__init__.py
@@ -1,2 +1,7 @@
-from .base import BaseMoEModelMixin, MoeModelOutputWithPastAndAuxLoss, PreTrainedMoEModelMixin
+# Local
+from .base import (
+    BaseMoEModelMixin,
+    MoeModelOutputWithPastAndAuxLoss,
+    PreTrainedMoEModelMixin,
+)
 from .main import CausalLMMoEModelMixin

--- a/src/instructlab/dolomite/hf_models/mixins/moe/base.py
+++ b/src/instructlab/dolomite/hf_models/mixins/moe/base.py
@@ -1,10 +1,13 @@
+# Standard
 from dataclasses import dataclass
 
-import torch
-import torch.nn as nn
+# Third Party
 from transformers import DynamicCache
 from transformers.modeling_outputs import MoeModelOutputWithPast
+import torch
+import torch.nn as nn
 
+# Local
 from ...config import CommonConfig
 from ...enums import AttentionHeadType, PositionEmbeddingType
 from ...modeling_utils import ParameterizedEmbedding, get_normalization_function
@@ -39,9 +42,13 @@ class BaseMoEModelMixin(BaseModelMixin):
 
         self.head_dim = self.embed_dim // self.num_heads
 
-        self.wte = ParameterizedEmbedding(config.vocab_size, self.embed_dim, std=self.initializer_range)
+        self.wte = ParameterizedEmbedding(
+            config.vocab_size, self.embed_dim, std=self.initializer_range
+        )
 
-        self.drop = nn.Identity() if config.embd_pdrop == 0 else nn.Dropout(config.embd_pdrop)
+        self.drop = (
+            nn.Identity() if config.embd_pdrop == 0 else nn.Dropout(config.embd_pdrop)
+        )
         self.h = nn.ModuleList(
             [
                 self.layer_class(
@@ -62,7 +69,9 @@ class BaseMoEModelMixin(BaseModelMixin):
             normalization_implementation=self.normalization_implementation,
         )
 
-        self.position_embedding_type = PositionEmbeddingType(config.position_embedding_type)
+        self.position_embedding_type = PositionEmbeddingType(
+            config.position_embedding_type
+        )
         self._setup_positional_encoding()
 
         # Initialize weights and apply final processing
@@ -116,7 +125,9 @@ class BaseMoEModelMixin(BaseModelMixin):
         #     attention_mask -> (batch_size, 1, query_length, key_length)
         # ==========================================================================================
 
-        past_key_values = DynamicCache() if use_cache and past_key_values is None else past_key_values
+        past_key_values = (
+            DynamicCache() if use_cache and past_key_values is None else past_key_values
+        )
         all_hidden_states = () if output_hidden_states else None
         all_router_logits = () if output_router_logits else None
         total_aux_loss = 0
@@ -188,7 +199,9 @@ class BaseMoEModelMixin(BaseModelMixin):
         tuple[torch.Tensor],
     ]:
         output_router_logits = (
-            output_router_logits if output_router_logits is not None else self.config.output_router_logits
+            output_router_logits
+            if output_router_logits is not None
+            else self.config.output_router_logits
         )
 
         return super()._prepare_a_bunch_of_stuff(

--- a/src/instructlab/dolomite/hf_models/mixins/moe/main.py
+++ b/src/instructlab/dolomite/hf_models/mixins/moe/main.py
@@ -1,7 +1,9 @@
-import torch
+# Third Party
 from transformers import DynamicCache
 from transformers.modeling_outputs import MoeCausalLMOutputWithPast
+import torch
 
+# Local
 from ...config import CommonConfig
 from ..dense import CausalLMModelMixin
 from .base import MoeModelOutputWithPastAndAuxLoss
@@ -32,18 +34,20 @@ class CausalLMMoEModelMixin(CausalLMModelMixin):
         max_seqlen: torch.Tensor | None = None,
         output_router_logits: bool | None = None,
     ) -> tuple | MoeCausalLMOutputWithPast:
-        input_ids, position_ids, token_type_ids, labels, cu_seqlens, max_seqlen = self.prepare_inputs_for_model(
-            input_ids=input_ids,
-            inputs_embeds=inputs_embeds,
-            position_ids=position_ids,
-            token_type_ids=token_type_ids,
-            labels=labels,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
-            past_key_values=past_key_values,
-            attention_mask=attention_mask,
-            use_cache=use_cache,
-            output_attentions=output_attentions,
+        input_ids, position_ids, token_type_ids, labels, cu_seqlens, max_seqlen = (
+            self.prepare_inputs_for_model(
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+                position_ids=position_ids,
+                token_type_ids=token_type_ids,
+                labels=labels,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                past_key_values=past_key_values,
+                attention_mask=attention_mask,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+            )
         )
 
         # ==========================================================================================
@@ -76,7 +80,9 @@ class CausalLMMoEModelMixin(CausalLMModelMixin):
         if self.m_width is not None:
             lm_logits = lm_logits / self.m_width
 
-        lm_loss = self.get_autoregressive_language_modeling_loss(lm_logits, labels, cu_seqlens)
+        lm_loss = self.get_autoregressive_language_modeling_loss(
+            lm_logits, labels, cu_seqlens
+        )
         aux_loss = transformer_outputs.aux_loss
 
         if lm_loss is None:

--- a/src/instructlab/dolomite/hf_models/mixins/moe_TP/__init__.py
+++ b/src/instructlab/dolomite/hf_models/mixins/moe_TP/__init__.py
@@ -1,2 +1,3 @@
+# Local
 from .base import BaseMoEModelMixin_TP, PreTrainedMoEModelMixin_TP
 from .main import CausalLMMoEModelMixin_TP

--- a/src/instructlab/dolomite/hf_models/mixins/moe_TP/base.py
+++ b/src/instructlab/dolomite/hf_models/mixins/moe_TP/base.py
@@ -1,5 +1,7 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from ....utils import ProcessGroupManager
 from ...config import CommonConfig
 from ...enums import AttentionHeadType, PositionEmbeddingType
@@ -10,7 +12,9 @@ from ..moe import BaseMoEModelMixin, PreTrainedMoEModelMixin
 
 class PreTrainedMoEModelMixin_TP(PreTrainedMoEModelMixin, PreTrainedModelMixin_TP):
     def __init__(self, config: CommonConfig, *args, **kwargs):
-        self.tensor_parallel_word_embeddings = kwargs.get("tensor_parallel_word_embeddings", False)
+        self.tensor_parallel_word_embeddings = kwargs.get(
+            "tensor_parallel_word_embeddings", False
+        )
         self.sequence_parallel = kwargs.get("sequence_parallel", False)
 
         super().__init__(config, *args, **kwargs)
@@ -68,7 +72,9 @@ class BaseMoEModelMixin_TP(BaseMoEModelMixin, BaseModelMixin_TP):
             sequence_parallel=self.sequence_parallel,
         )
 
-        self.position_embedding_type = PositionEmbeddingType(config.position_embedding_type)
+        self.position_embedding_type = PositionEmbeddingType(
+            config.position_embedding_type
+        )
         self._setup_positional_encoding()
 
         # Initialize weights and apply final processing

--- a/src/instructlab/dolomite/hf_models/model_conversion/__init__.py
+++ b/src/instructlab/dolomite/hf_models/model_conversion/__init__.py
@@ -1,9 +1,10 @@
+# Third Party
 from transformers import AutoConfig
 
+# Local
 from .bigcode import export_to_huggingface_bigcode, import_from_huggingface_bigcode
 from .granite import export_to_huggingface_granite, import_from_huggingface_granite
 from .llama import export_to_huggingface_llama, import_from_huggingface_llama
-
 
 _MODEL_IMPORT_FUNCTIONS = {
     "gpt_bigcode": import_from_huggingface_bigcode,
@@ -17,7 +18,9 @@ def import_from_huggingface(pretrained_model_name_or_path: str, save_path: str) 
     model_type = config.model_type
 
     if model_type not in _MODEL_IMPORT_FUNCTIONS:
-        raise NotImplementedError(f"the current model_type ({model_type}) is not yet supported")
+        raise NotImplementedError(
+            f"the current model_type ({model_type}) is not yet supported"
+        )
 
     import_function = _MODEL_IMPORT_FUNCTIONS[model_type]
     import_function(pretrained_model_name_or_path, save_path)
@@ -30,9 +33,13 @@ _MODEL_EXPORT_FUNCTIONS = {
 }
 
 
-def export_to_huggingface(pretrained_model_name_or_path: str, save_path: str, model_type: str) -> None:
+def export_to_huggingface(
+    pretrained_model_name_or_path: str, save_path: str, model_type: str
+) -> None:
     if model_type not in _MODEL_EXPORT_FUNCTIONS:
-        raise NotImplementedError(f"the current model_type ({model_type}) is not yet supported")
+        raise NotImplementedError(
+            f"the current model_type ({model_type}) is not yet supported"
+        )
 
     export_function = _MODEL_EXPORT_FUNCTIONS[model_type]
     export_function(pretrained_model_name_or_path, save_path)

--- a/src/instructlab/dolomite/hf_models/model_conversion/bigcode.py
+++ b/src/instructlab/dolomite/hf_models/model_conversion/bigcode.py
@@ -1,12 +1,23 @@
+# Standard
 import shutil
 
-from transformers import AutoConfig, AutoTokenizer, GenerationConfig, GPTBigCodeConfig, GPTBigCodeForCausalLM
+# Third Party
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    GenerationConfig,
+    GPTBigCodeConfig,
+    GPTBigCodeForCausalLM,
+)
 
+# Local
 from ..enums import AttentionHeadType, PositionEmbeddingType
 from ..models import GPTDolomiteConfig
 
 
-def import_from_huggingface_bigcode(pretrained_model_name_or_path: str, save_path: str) -> None:
+def import_from_huggingface_bigcode(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
     shutil.copytree(pretrained_model_name_or_path, save_path)
 
     original_config: GPTBigCodeConfig = AutoConfig.from_pretrained(save_path)
@@ -23,7 +34,9 @@ def import_from_huggingface_bigcode(pretrained_model_name_or_path: str, save_pat
         pass
 
 
-def _import_config_from_huggingface(original_config: GPTBigCodeConfig) -> GPTDolomiteConfig:
+def _import_config_from_huggingface(
+    original_config: GPTBigCodeConfig,
+) -> GPTDolomiteConfig:
     assert original_config.activation_function in ["gelu_pytorch_tanh", "gelu"]
 
     config = GPTDolomiteConfig(
@@ -52,7 +65,9 @@ def _import_config_from_huggingface(original_config: GPTBigCodeConfig) -> GPTDol
     return config
 
 
-def export_to_huggingface_bigcode(pretrained_model_name_or_path: str, save_path: str) -> None:
+def export_to_huggingface_bigcode(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
     shutil.copytree(pretrained_model_name_or_path, save_path)
 
     config: GPTDolomiteConfig = AutoConfig.from_pretrained(save_path)
@@ -72,8 +87,14 @@ def export_to_huggingface_bigcode(pretrained_model_name_or_path: str, save_path:
 def _export_config_to_huggingface(config: GPTDolomiteConfig) -> GPTBigCodeConfig:
     assert config.activation_function == "gelu_pytorch_tanh"
     assert config.normalization_function == "layernorm"
-    assert AttentionHeadType(config.attention_head_type) in [AttentionHeadType.mha, AttentionHeadType.mqa]
-    assert PositionEmbeddingType(config.position_embedding_type) == PositionEmbeddingType.learned_absolute
+    assert AttentionHeadType(config.attention_head_type) in [
+        AttentionHeadType.mha,
+        AttentionHeadType.mqa,
+    ]
+    assert (
+        PositionEmbeddingType(config.position_embedding_type)
+        == PositionEmbeddingType.learned_absolute
+    )
     assert config.m_emb is None
     assert config.m_residual is None
     assert config.m_width is None

--- a/src/instructlab/dolomite/hf_models/model_conversion/granite.py
+++ b/src/instructlab/dolomite/hf_models/model_conversion/granite.py
@@ -1,19 +1,28 @@
+# Third Party
 from transformers import AutoConfig, AutoTokenizer, GenerationConfig
 
+# Local
 from ...utils import SafeTensorsWeightsManager, download_repo
 from ..enums import AttentionHeadType
 from ..models import GPTDolomiteConfig
-from .llama import _export_state_dict_to_huggingface, _import_state_dict_from_huggingface
-
+from .llama import (
+    _export_state_dict_to_huggingface,
+    _import_state_dict_from_huggingface,
+)
 
 try:
+    # Third Party
     from transformers import GraniteConfig, GraniteForCausalLM
 except:
     GraniteConfig = None
 
 
-def import_from_huggingface_granite(pretrained_model_name_or_path: str, save_path: str) -> None:
-    original_config, tokenizer, downloaded_model_path = download_repo(pretrained_model_name_or_path)
+def import_from_huggingface_granite(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
+    original_config, tokenizer, downloaded_model_path = download_repo(
+        pretrained_model_name_or_path
+    )
     config = _import_config_from_huggingface(original_config)
 
     safetensors_weights_manager = SafeTensorsWeightsManager(downloaded_model_path)
@@ -36,7 +45,9 @@ def import_from_huggingface_granite(pretrained_model_name_or_path: str, save_pat
         tokenizer.save_pretrained(save_path, legacy_format=False)
 
 
-def _import_config_from_huggingface(original_config: GraniteConfig) -> GPTDolomiteConfig:
+def _import_config_from_huggingface(
+    original_config: GraniteConfig,
+) -> GPTDolomiteConfig:
     assert original_config.hidden_act == "silu"
 
     if original_config.num_attention_heads == original_config.num_key_value_heads:
@@ -71,20 +82,32 @@ def _import_config_from_huggingface(original_config: GraniteConfig) -> GPTDolomi
         bos_token_id=original_config.bos_token_id,
         eos_token_id=original_config.eos_token_id,
         pad_token_id=original_config.pad_token_id,
-        m_emb=None if original_config.embedding_multiplier == 1 else original_config.embedding_multiplier,
-        m_residual=None if original_config.residual_multiplier == 1 else original_config.residual_multiplier,
-        m_width=None if original_config.logits_scaling == 1 else original_config.logits_scaling,
+        m_emb=None
+        if original_config.embedding_multiplier == 1
+        else original_config.embedding_multiplier,
+        m_residual=None
+        if original_config.residual_multiplier == 1
+        else original_config.residual_multiplier,
+        m_width=None
+        if original_config.logits_scaling == 1
+        else original_config.logits_scaling,
         attention_multiplier=original_config.attention_multiplier,
     )
 
     return config
 
 
-def export_to_huggingface_granite(pretrained_model_name_or_path: str, save_path: str) -> None:
-    config: GPTDolomiteConfig = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+def export_to_huggingface_granite(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
+    config: GPTDolomiteConfig = AutoConfig.from_pretrained(
+        pretrained_model_name_or_path
+    )
     original_config = _export_config_to_huggingface(config)
 
-    safetensors_weights_manager = SafeTensorsWeightsManager(pretrained_model_name_or_path)
+    safetensors_weights_manager = SafeTensorsWeightsManager(
+        pretrained_model_name_or_path
+    )
     state_dict = _export_state_dict_to_huggingface(
         safetensors_weights_manager,
         config.n_layer,
@@ -119,7 +142,9 @@ def _export_config_to_huggingface(config: GPTDolomiteConfig) -> GraniteConfig:
         num_hidden_layers=config.n_layer,
         num_attention_heads=config.n_head,
         num_key_value_heads=config.num_key_value_heads,
-        intermediate_size=4 * config.n_embd if config.n_inner is None else config.n_inner,
+        intermediate_size=4 * config.n_embd
+        if config.n_inner is None
+        else config.n_inner,
         hidden_act="silu",
         rms_norm_eps=config.layer_norm_epsilon,
         use_cache=config.use_cache,

--- a/src/instructlab/dolomite/hf_models/model_conversion/llama.py
+++ b/src/instructlab/dolomite/hf_models/model_conversion/llama.py
@@ -1,5 +1,13 @@
-from transformers import AutoConfig, AutoTokenizer, GenerationConfig, LlamaConfig, LlamaForCausalLM
+# Third Party
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    GenerationConfig,
+    LlamaConfig,
+    LlamaForCausalLM,
+)
 
+# Local
 from ...utils import SafeTensorsWeightsManager, download_repo
 from ..enums import AttentionHeadType
 from ..modeling_utils import (
@@ -7,11 +15,18 @@ from ..modeling_utils import (
     split_query_key_value_tensor_for_attention,
 )
 from ..models import GPTDolomiteConfig
-from ..models.gpt_dolomite import interleave_up_gate_tensor_for_mlp, split_up_gate_tensor_for_mlp
+from ..models.gpt_dolomite import (
+    interleave_up_gate_tensor_for_mlp,
+    split_up_gate_tensor_for_mlp,
+)
 
 
-def import_from_huggingface_llama(pretrained_model_name_or_path: str, save_path: str) -> None:
-    original_config, tokenizer, downloaded_model_path = download_repo(pretrained_model_name_or_path)
+def import_from_huggingface_llama(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
+    original_config, tokenizer, downloaded_model_path = download_repo(
+        pretrained_model_name_or_path
+    )
     config = _import_config_from_huggingface(original_config)
 
     safetensors_weights_manager = SafeTensorsWeightsManager(downloaded_model_path)
@@ -83,54 +98,100 @@ def _import_state_dict_from_huggingface(
     attention_head_type: AttentionHeadType,
 ) -> None:
     state_dict = {
-        "transformer.wte.weight": safetensors_weights_manager.get_tensor("model.embed_tokens.weight"),
-        "transformer.ln_f.weight": safetensors_weights_manager.get_tensor("model.norm.weight"),
+        "transformer.wte.weight": safetensors_weights_manager.get_tensor(
+            "model.embed_tokens.weight"
+        ),
+        "transformer.ln_f.weight": safetensors_weights_manager.get_tensor(
+            "model.norm.weight"
+        ),
     }
 
     if safetensors_weights_manager.has_tensor("lm_head.weight"):
-        state_dict["lm_head.weight"] = safetensors_weights_manager.get_tensor("lm_head.weight")
+        state_dict["lm_head.weight"] = safetensors_weights_manager.get_tensor(
+            "lm_head.weight"
+        )
 
     for layer_idx in range(num_layers):
-        state_dict[f"transformer.h.{layer_idx}.ln_1.weight"] = safetensors_weights_manager.get_tensor(
-            f"model.layers.{layer_idx}.input_layernorm.weight"
+        state_dict[f"transformer.h.{layer_idx}.ln_1.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"model.layers.{layer_idx}.input_layernorm.weight"
+            )
         )
-        state_dict[f"transformer.h.{layer_idx}.ln_2.weight"] = safetensors_weights_manager.get_tensor(
-            f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+        state_dict[f"transformer.h.{layer_idx}.ln_2.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+            )
         )
 
-        state_dict[f"transformer.h.{layer_idx}.mlp.c_fc.weight"] = interleave_up_gate_tensor_for_mlp(
-            safetensors_weights_manager.get_tensor(f"model.layers.{layer_idx}.mlp.up_proj.weight"),
-            safetensors_weights_manager.get_tensor(f"model.layers.{layer_idx}.mlp.gate_proj.weight"),
+        state_dict[f"transformer.h.{layer_idx}.mlp.c_fc.weight"] = (
+            interleave_up_gate_tensor_for_mlp(
+                safetensors_weights_manager.get_tensor(
+                    f"model.layers.{layer_idx}.mlp.up_proj.weight"
+                ),
+                safetensors_weights_manager.get_tensor(
+                    f"model.layers.{layer_idx}.mlp.gate_proj.weight"
+                ),
+            )
         )
         if f"model.layers.{layer_idx}.mlp.up_proj.bias" in safetensors_weights_manager:
-            state_dict[f"transformer.h.{layer_idx}.mlp.c_fc.bias"] = interleave_up_gate_tensor_for_mlp(
-                safetensors_weights_manager.get_tensor(f"model.layers.{layer_idx}.mlp.up_proj.bias"),
-                safetensors_weights_manager.get_tensor(f"model.layers.{layer_idx}.mlp.gate_proj.bias"),
+            state_dict[f"transformer.h.{layer_idx}.mlp.c_fc.bias"] = (
+                interleave_up_gate_tensor_for_mlp(
+                    safetensors_weights_manager.get_tensor(
+                        f"model.layers.{layer_idx}.mlp.up_proj.bias"
+                    ),
+                    safetensors_weights_manager.get_tensor(
+                        f"model.layers.{layer_idx}.mlp.gate_proj.bias"
+                    ),
+                )
             )
 
-        state_dict[f"transformer.h.{layer_idx}.mlp.c_proj.weight"] = safetensors_weights_manager.get_tensor(
-            f"model.layers.{layer_idx}.mlp.down_proj.weight"
+        state_dict[f"transformer.h.{layer_idx}.mlp.c_proj.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"model.layers.{layer_idx}.mlp.down_proj.weight"
+            )
         )
-        if f"model.layers.{layer_idx}.mlp.down_proj.bias" in safetensors_weights_manager:
-            state_dict[f"transformer.h.{layer_idx}.mlp.c_proj.bias"] = safetensors_weights_manager.get_tensor(
-                f"model.layers.{layer_idx}.mlp.down_proj.bias"
+        if (
+            f"model.layers.{layer_idx}.mlp.down_proj.bias"
+            in safetensors_weights_manager
+        ):
+            state_dict[f"transformer.h.{layer_idx}.mlp.c_proj.bias"] = (
+                safetensors_weights_manager.get_tensor(
+                    f"model.layers.{layer_idx}.mlp.down_proj.bias"
+                )
             )
 
-        state_dict[f"transformer.h.{layer_idx}.attn.c_attn.weight"] = interleave_query_key_value_tensor_for_attention(
-            safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.q_proj.weight"),
-            safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.k_proj.weight"),
-            safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.v_proj.weight"),
-            num_heads,
-            num_key_value_heads,
-            head_dim,
-            attention_head_type,
+        state_dict[f"transformer.h.{layer_idx}.attn.c_attn.weight"] = (
+            interleave_query_key_value_tensor_for_attention(
+                safetensors_weights_manager.get_slice(
+                    f"model.layers.{layer_idx}.self_attn.q_proj.weight"
+                ),
+                safetensors_weights_manager.get_slice(
+                    f"model.layers.{layer_idx}.self_attn.k_proj.weight"
+                ),
+                safetensors_weights_manager.get_slice(
+                    f"model.layers.{layer_idx}.self_attn.v_proj.weight"
+                ),
+                num_heads,
+                num_key_value_heads,
+                head_dim,
+                attention_head_type,
+            )
         )
-        if f"model.layers.{layer_idx}.self_attn.q_proj.bias" in safetensors_weights_manager:
+        if (
+            f"model.layers.{layer_idx}.self_attn.q_proj.bias"
+            in safetensors_weights_manager
+        ):
             state_dict[f"transformer.h.{layer_idx}.attn.c_attn.bias"] = (
                 interleave_query_key_value_tensor_for_attention(
-                    safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.q_proj.bias"),
-                    safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.k_proj.bias"),
-                    safetensors_weights_manager.get_slice(f"model.layers.{layer_idx}.self_attn.v_proj.bias"),
+                    safetensors_weights_manager.get_slice(
+                        f"model.layers.{layer_idx}.self_attn.q_proj.bias"
+                    ),
+                    safetensors_weights_manager.get_slice(
+                        f"model.layers.{layer_idx}.self_attn.k_proj.bias"
+                    ),
+                    safetensors_weights_manager.get_slice(
+                        f"model.layers.{layer_idx}.self_attn.v_proj.bias"
+                    ),
                     num_heads,
                     num_key_value_heads,
                     head_dim,
@@ -138,22 +199,35 @@ def _import_state_dict_from_huggingface(
                 )
             )
 
-        state_dict[f"transformer.h.{layer_idx}.attn.c_proj.weight"] = safetensors_weights_manager.get_tensor(
-            f"model.layers.{layer_idx}.self_attn.o_proj.weight"
+        state_dict[f"transformer.h.{layer_idx}.attn.c_proj.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"model.layers.{layer_idx}.self_attn.o_proj.weight"
+            )
         )
-        if f"model.layers.{layer_idx}.self_attn.o_proj.bias" in safetensors_weights_manager:
-            state_dict[f"transformer.h.{layer_idx}.attn.c_proj.bias"] = safetensors_weights_manager.get_tensor(
-                f"model.layers.{layer_idx}.self_attn.o_proj.bias"
+        if (
+            f"model.layers.{layer_idx}.self_attn.o_proj.bias"
+            in safetensors_weights_manager
+        ):
+            state_dict[f"transformer.h.{layer_idx}.attn.c_proj.bias"] = (
+                safetensors_weights_manager.get_tensor(
+                    f"model.layers.{layer_idx}.self_attn.o_proj.bias"
+                )
             )
 
     return state_dict
 
 
-def export_to_huggingface_llama(pretrained_model_name_or_path: str, save_path: str) -> None:
-    config: GPTDolomiteConfig = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+def export_to_huggingface_llama(
+    pretrained_model_name_or_path: str, save_path: str
+) -> None:
+    config: GPTDolomiteConfig = AutoConfig.from_pretrained(
+        pretrained_model_name_or_path
+    )
     original_config = _export_config_to_huggingface(config)
 
-    safetensors_weights_manager = SafeTensorsWeightsManager(pretrained_model_name_or_path)
+    safetensors_weights_manager = SafeTensorsWeightsManager(
+        pretrained_model_name_or_path
+    )
     state_dict = _export_state_dict_to_huggingface(
         safetensors_weights_manager,
         config.n_layer,
@@ -192,7 +266,9 @@ def _export_config_to_huggingface(config: GPTDolomiteConfig) -> LlamaConfig:
         num_hidden_layers=config.n_layer,
         num_attention_heads=config.n_head,
         num_key_value_heads=config.num_key_value_heads,
-        intermediate_size=4 * config.n_embd if config.n_inner is None else config.n_inner,
+        intermediate_size=4 * config.n_embd
+        if config.n_inner is None
+        else config.n_inner,
         hidden_act="silu",
         rms_norm_eps=config.layer_norm_epsilon,
         use_cache=config.use_cache,
@@ -221,71 +297,101 @@ def _export_state_dict_to_huggingface(
     attention_head_type: AttentionHeadType,
 ) -> None:
     state_dict = {
-        "model.embed_tokens.weight": safetensors_weights_manager.get_tensor("transformer.wte.weight"),
-        "model.norm.weight": safetensors_weights_manager.get_tensor("transformer.ln_f.weight"),
+        "model.embed_tokens.weight": safetensors_weights_manager.get_tensor(
+            "transformer.wte.weight"
+        ),
+        "model.norm.weight": safetensors_weights_manager.get_tensor(
+            "transformer.ln_f.weight"
+        ),
     }
 
     if safetensors_weights_manager.has_tensor("lm_head.weight"):
-        state_dict["lm_head.weight"] = safetensors_weights_manager.get_tensor("lm_head.weight")
+        state_dict["lm_head.weight"] = safetensors_weights_manager.get_tensor(
+            "lm_head.weight"
+        )
 
     for layer_idx in range(num_layers):
-        state_dict[f"model.layers.{layer_idx}.input_layernorm.weight"] = safetensors_weights_manager.get_tensor(
-            f"transformer.h.{layer_idx}.ln_1.weight"
+        state_dict[f"model.layers.{layer_idx}.input_layernorm.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"transformer.h.{layer_idx}.ln_1.weight"
+            )
         )
         state_dict[f"model.layers.{layer_idx}.post_attention_layernorm.weight"] = (
-            safetensors_weights_manager.get_tensor(f"transformer.h.{layer_idx}.ln_2.weight")
+            safetensors_weights_manager.get_tensor(
+                f"transformer.h.{layer_idx}.ln_2.weight"
+            )
         )
 
         up_weight, gate_weight = split_up_gate_tensor_for_mlp(
-            safetensors_weights_manager.get_tensor(f"transformer.h.{layer_idx}.mlp.c_fc.weight")
+            safetensors_weights_manager.get_tensor(
+                f"transformer.h.{layer_idx}.mlp.c_fc.weight"
+            )
         )
         state_dict[f"model.layers.{layer_idx}.mlp.up_proj.weight"] = up_weight
         state_dict[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = gate_weight
 
         if f"transformer.h.{layer_idx}.mlp.c_fc.bias" in safetensors_weights_manager:
             up_bias, gate_bias = split_up_gate_tensor_for_mlp(
-                safetensors_weights_manager.get_tensor(f"transformer.h.{layer_idx}.mlp.c_fc.bias")
+                safetensors_weights_manager.get_tensor(
+                    f"transformer.h.{layer_idx}.mlp.c_fc.bias"
+                )
             )
             state_dict[f"model.layers.{layer_idx}.mlp.up_proj.bias"] = up_bias
             state_dict[f"model.layers.{layer_idx}.mlp.gate_proj.bias"] = gate_bias
 
-        state_dict[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = safetensors_weights_manager.get_tensor(
-            f"transformer.h.{layer_idx}.mlp.c_proj.weight"
+        state_dict[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"transformer.h.{layer_idx}.mlp.c_proj.weight"
+            )
         )
         if f"transformer.h.{layer_idx}.mlp.c_proj.bias" in safetensors_weights_manager:
-            state_dict[f"model.layers.{layer_idx}.mlp.down_proj.bias"] = safetensors_weights_manager.get_tensor(
-                f"transformer.h.{layer_idx}.mlp.c_proj.bias"
+            state_dict[f"model.layers.{layer_idx}.mlp.down_proj.bias"] = (
+                safetensors_weights_manager.get_tensor(
+                    f"transformer.h.{layer_idx}.mlp.c_proj.bias"
+                )
             )
 
-        query_weight, key_weight, value_weight = split_query_key_value_tensor_for_attention(
-            safetensors_weights_manager.get_tensor(f"transformer.h.{layer_idx}.attn.c_attn.weight"),
-            num_heads,
-            num_key_value_heads,
-            head_dim,
-            attention_head_type,
+        query_weight, key_weight, value_weight = (
+            split_query_key_value_tensor_for_attention(
+                safetensors_weights_manager.get_tensor(
+                    f"transformer.h.{layer_idx}.attn.c_attn.weight"
+                ),
+                num_heads,
+                num_key_value_heads,
+                head_dim,
+                attention_head_type,
+            )
         )
         state_dict[f"model.layers.{layer_idx}.self_attn.q_proj.weight"] = query_weight
         state_dict[f"model.layers.{layer_idx}.self_attn.k_proj.weight"] = key_weight
         state_dict[f"model.layers.{layer_idx}.self_attn.v_proj.weight"] = value_weight
 
         if f"transformer.h.{layer_idx}.attn.c_attn.bias" in safetensors_weights_manager:
-            query_bias, key_bias, value_bias = split_query_key_value_tensor_for_attention(
-                safetensors_weights_manager.get_tensor(f"transformer.h.{layer_idx}.attn.c_attn.bias"),
-                num_heads,
-                num_key_value_heads,
-                head_dim,
-                attention_head_type,
+            query_bias, key_bias, value_bias = (
+                split_query_key_value_tensor_for_attention(
+                    safetensors_weights_manager.get_tensor(
+                        f"transformer.h.{layer_idx}.attn.c_attn.bias"
+                    ),
+                    num_heads,
+                    num_key_value_heads,
+                    head_dim,
+                    attention_head_type,
+                )
             )
             state_dict[f"model.layers.{layer_idx}.self_attn.q_proj.bias"] = query_bias
             state_dict[f"model.layers.{layer_idx}.self_attn.k_proj.bias"] = key_bias
             state_dict[f"model.layers.{layer_idx}.self_attn.v_proj.bias"] = value_bias
 
-        state_dict[f"model.layers.{layer_idx}.self_attn.o_proj.weight"] = safetensors_weights_manager.get_tensor(
-            f"transformer.h.{layer_idx}.attn.c_proj.weight"
+        state_dict[f"model.layers.{layer_idx}.self_attn.o_proj.weight"] = (
+            safetensors_weights_manager.get_tensor(
+                f"transformer.h.{layer_idx}.attn.c_proj.weight"
+            )
         )
         if f"transformer.h.{layer_idx}.attn.c_proj.bias" in safetensors_weights_manager:
-            state_dict[f"model.layers.{layer_idx}.self_attn.o_proj.bias"] = safetensors_weights_manager.get_tensor(
-                f"transformer.h.{layer_idx}.attn.c_proj.bias"
+            state_dict[f"model.layers.{layer_idx}.self_attn.o_proj.bias"] = (
+                safetensors_weights_manager.get_tensor(
+                    f"transformer.h.{layer_idx}.attn.c_proj.bias"
+                )
             )
 
     return state_dict

--- a/src/instructlab/dolomite/hf_models/modeling_utils/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/__init__.py
@@ -1,3 +1,4 @@
+# Local
 from .activations import get_activation_function, is_glu
 from .attention import (
     SDPA,

--- a/src/instructlab/dolomite/hf_models/modeling_utils/activations/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/activations/__init__.py
@@ -1,5 +1,7 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from .base import get_base_activation
 from .glu import get_glu_activation, is_glu
 

--- a/src/instructlab/dolomite/hf_models/modeling_utils/activations/base.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/activations/base.py
@@ -1,6 +1,6 @@
-import torch.nn as nn
+# Third Party
 from transformers.activations import ACT2CLS, ClassInstantier
-
+import torch.nn as nn
 
 _BASE_ACTIVATIONS = {
     "celu": nn.modules.CELU,

--- a/src/instructlab/dolomite/hf_models/modeling_utils/activations/glu.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/activations/glu.py
@@ -1,8 +1,9 @@
+# Third Party
 import torch
 import torch.nn as nn
 
+# Local
 from .base import get_base_activation
-
 
 _GLU_BASE_MAPPING = {
     "ceglu": "celu",

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/__init__.py
@@ -1,7 +1,10 @@
+# Standard
 import inspect
 
+# Third Party
 import torch
 
+# Local
 from ...config import CommonConfig
 from ...enums import AttentionHeadType
 from .base import Attention
@@ -17,7 +20,6 @@ from .utils import (
     split_query_key_value_tensor_for_mha,
     split_query_key_value_tensor_for_mqa,
 )
-
 
 _ATTENTION_MODULES = {
     "eager": Attention,
@@ -69,7 +71,9 @@ def interleave_query_key_value_tensor_for_attention(
 ) -> torch.Tensor:
     if attention_head_type.value in _INTERLEAVE_FUNCTIONS:
         interleave_function = _INTERLEAVE_FUNCTIONS[attention_head_type.value]
-        interleave_function_parameters = inspect.signature(interleave_function).parameters.keys()
+        interleave_function_parameters = inspect.signature(
+            interleave_function
+        ).parameters.keys()
 
         parameters_to_pass = {}
         this_function_parameters = locals()

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/base.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/base.py
@@ -1,10 +1,13 @@
+# Standard
 import math
 
+# Third Party
+from transformers import DynamicCache
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import DynamicCache
 
+# Local
 from ...config import CommonConfig
 from ...enums import AttentionHeadType, InitMethod, PositionEmbeddingType
 from ...utils import divide_if_divisible
@@ -14,7 +17,9 @@ from .utils import repeat_key_value
 
 
 class Attention(nn.Module):
-    def __init__(self, config: CommonConfig, causal: bool, layer_idx: int | None = None) -> None:
+    def __init__(
+        self, config: CommonConfig, causal: bool, layer_idx: int | None = None
+    ) -> None:
         super().__init__()
 
         self.causal = causal
@@ -36,7 +41,9 @@ class Attention(nn.Module):
 
         self.attention_head_type = AttentionHeadType(config.attention_head_type)
 
-        self.position_embedding_type = PositionEmbeddingType(config.position_embedding_type)
+        self.position_embedding_type = PositionEmbeddingType(
+            config.position_embedding_type
+        )
         self.scale_attn_weights = config.scale_attn_weights
         self.attention_multiplier = config.attention_multiplier
 
@@ -64,9 +71,13 @@ class Attention(nn.Module):
             if self.num_key_value_heads is None:
                 self.num_key_value_heads = 1
 
-            assert self.num_key_value_heads == 1, f"{self.__class__.__name__} should have 1 head for keys and values"
+            assert (
+                self.num_key_value_heads == 1
+            ), f"{self.__class__.__name__} should have 1 head for keys and values"
         else:
-            raise ValueError(f"unexpected attention_head_type ({self.attention_head_type})")
+            raise ValueError(
+                f"unexpected attention_head_type ({self.attention_head_type})"
+            )
 
         # note that the actual layout is different for the output and depends on whether we are using MHA, MQA or GQA
         # (self.hidden_size + 2 * self.num_key_value_heads * self.head_dim) is just the actual number output features
@@ -83,15 +94,23 @@ class Attention(nn.Module):
         std = initializer_range / math.sqrt(2 * n_layer)
         if init_method == InitMethod.mup:
             std /= math.sqrt(m_width)
-        self.c_proj = ParameterizedLinear(self.hidden_size, self.hidden_size, bias=self.add_bias, std=std)
+        self.c_proj = ParameterizedLinear(
+            self.hidden_size, self.hidden_size, bias=self.add_bias, std=std
+        )
 
         self.attn_pdrop = config.attn_pdrop
         self.resid_pdrop = config.resid_pdrop
 
-        self.attn_dropout = nn.Identity() if self.attn_pdrop == 0 else nn.Dropout(self.attn_pdrop)
-        self.resid_dropout = nn.Identity() if self.resid_pdrop == 0 else nn.Dropout(self.resid_pdrop)
+        self.attn_dropout = (
+            nn.Identity() if self.attn_pdrop == 0 else nn.Dropout(self.attn_pdrop)
+        )
+        self.resid_dropout = (
+            nn.Identity() if self.resid_pdrop == 0 else nn.Dropout(self.resid_pdrop)
+        )
 
-    def _prepare_qkv_for_forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def _prepare_qkv_for_forward(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         # ==========================================================================================
         # hidden_states -> (batch_size, query_length, num_heads * head_dim)
         # ==========================================================================================
@@ -111,7 +130,9 @@ class Attention(nn.Module):
         elif self.attention_head_type == AttentionHeadType.mqa:
             query, key, value = self._prepare_qkv_for_forward_mqa(hidden_states)
         else:
-            raise ValueError(f"unexpected attention_head_type ({self.attention_head_type})")
+            raise ValueError(
+                f"unexpected attention_head_type ({self.attention_head_type})"
+            )
 
         # ==========================================================================================
         # query -> (batch_size, num_heads, query_length, head_dim)
@@ -138,10 +159,17 @@ class Attention(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         batch_size, query_length = hidden_states.shape[:-1]
 
-        hidden_states = hidden_states.view(batch_size, query_length, self.num_key_value_heads, -1)
+        hidden_states = hidden_states.view(
+            batch_size, query_length, self.num_key_value_heads, -1
+        )
 
         query, key, value = hidden_states.split(
-            ((self.num_heads // self.num_key_value_heads) * self.head_dim, self.head_dim, self.head_dim), dim=-1
+            (
+                (self.num_heads // self.num_key_value_heads) * self.head_dim,
+                self.head_dim,
+                self.head_dim,
+            ),
+            dim=-1,
         )
 
         # this needs to be a reshape instead of view sadly
@@ -158,7 +186,9 @@ class Attention(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         batch_size, query_length = hidden_states.shape[:-1]
 
-        query, key, value = hidden_states.split((self.hidden_size, self.head_dim, self.head_dim), dim=-1)
+        query, key, value = hidden_states.split(
+            (self.hidden_size, self.head_dim, self.head_dim), dim=-1
+        )
 
         query = query.view(batch_size, query_length, self.num_heads, -1)
 
@@ -233,16 +263,20 @@ class Attention(nn.Module):
 
         if attention_mask is None:
             attn_weights = torch.empty(
-                (batch_size * self.num_heads, query_length, key_length), device=query.device, dtype=query.dtype
+                (batch_size * self.num_heads, query_length, key_length),
+                device=query.device,
+                dtype=query.dtype,
             )
             beta = 0
         else:
-            attn_weights = attention_mask.expand(-1, self.num_heads, -1, -1).reshape(-1, query_length, key_length)
+            attn_weights = attention_mask.expand(-1, self.num_heads, -1, -1).reshape(
+                -1, query_length, key_length
+            )
             beta = 1
 
-        attn_weights = torch.baddbmm(attn_weights, query, key, beta=beta, alpha=self._get_softmax_scale(False)).view(
-            batch_size, self.num_heads, query_length, key_length
-        )
+        attn_weights = torch.baddbmm(
+            attn_weights, query, key, beta=beta, alpha=self._get_softmax_scale(False)
+        ).view(batch_size, self.num_heads, query_length, key_length)
 
         # ==========================================================================================
         # attn_weights -> (batch_size, num_heads, query_length, key_length)
@@ -263,7 +297,9 @@ class Attention(nn.Module):
         # ==========================================================================================
 
         attn_output = attn_output.transpose(1, 2)
-        attn_output = attn_output.reshape(batch_size, -1, self.num_heads * self.head_dim)
+        attn_output = attn_output.reshape(
+            batch_size, -1, self.num_heads * self.head_dim
+        )
 
         # ==========================================================================================
         # attn_output -> (batch_size, query_length, num_heads * head_dim)

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/flash.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/flash.py
@@ -1,7 +1,9 @@
-import torch
+# Third Party
 from transformers import DynamicCache
 from transformers.modeling_flash_attention_utils import _flash_attention_forward
+import torch
 
+# Local
 from ...enums import AttentionHeadType, PositionEmbeddingType
 from ..position_embedding import apply_rotary_pos_emb
 from .base import Attention

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/padding_free.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/padding_free.py
@@ -1,13 +1,15 @@
-import torch
+# Third Party
 from transformers import DynamicCache
+import torch
 
+# Local
 from ....utils import is_flash_attention_available
 from ...enums import PositionEmbeddingType
 from ..position_embedding import apply_rotary_pos_emb
 from .base import Attention
 
-
 if is_flash_attention_available():
+    # Third Party
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
 
 
@@ -94,7 +96,12 @@ class PaddingFreeAttention(Attention):
         hidden_states = hidden_states.view(total_q, self.num_key_value_heads, -1)
 
         query, key, value = hidden_states.split(
-            ((self.num_heads // self.num_key_value_heads) * self.head_dim, self.head_dim, self.head_dim), dim=-1
+            (
+                (self.num_heads // self.num_key_value_heads) * self.head_dim,
+                self.head_dim,
+                self.head_dim,
+            ),
+            dim=-1,
         )
 
         # this needs to be a reshape instead of view sadly
@@ -107,7 +114,9 @@ class PaddingFreeAttention(Attention):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         total_q = hidden_states.shape[0]
 
-        query, key, value = hidden_states.split((self.hidden_size, self.head_dim, self.head_dim), dim=-1)
+        query, key, value = hidden_states.split(
+            (self.hidden_size, self.head_dim, self.head_dim), dim=-1
+        )
 
         query = query.view(total_q, self.num_heads, -1)
         key = key.unsqueeze(1)

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/sdpa.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/sdpa.py
@@ -1,7 +1,9 @@
+# Third Party
+from transformers import DynamicCache
 import torch
 import torch.nn.functional as F
-from transformers import DynamicCache
 
+# Local
 from ...enums import PositionEmbeddingType
 from ..position_embedding import apply_rotary_pos_emb
 from .base import Attention
@@ -71,7 +73,9 @@ class SDPA(Attention):
 
         batch_size = attn_output.shape[0]
         attn_output = attn_output.transpose(1, 2)
-        attn_output = attn_output.reshape(batch_size, -1, self.num_heads * self.head_dim)
+        attn_output = attn_output.reshape(
+            batch_size, -1, self.num_heads * self.head_dim
+        )
 
         # ==========================================================================================
         # attn_output -> (batch_size, query_length, num_heads * head_dim)

--- a/src/instructlab/dolomite/hf_models/modeling_utils/attention/utils.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/attention/utils.py
@@ -1,3 +1,4 @@
+# Third Party
 import torch
 
 
@@ -61,14 +62,21 @@ def interleave_query_key_value_tensor_for_gqa(
 
 
 def split_query_key_value_tensor_for_gqa(
-    query_key_value_weight: torch.Tensor, num_heads: int, num_key_value_heads: int, head_dim: int
+    query_key_value_weight: torch.Tensor,
+    num_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     query_heads_per_group = num_heads // num_key_value_heads
     original_shape = query_key_value_weight.shape
 
-    query_key_value_weight = query_key_value_weight.view(num_key_value_heads, (query_heads_per_group + 2), -1)
+    query_key_value_weight = query_key_value_weight.view(
+        num_key_value_heads, (query_heads_per_group + 2), -1
+    )
 
-    query_weight, key_weight, value_weight = query_key_value_weight.split((query_heads_per_group, 1, 1), 1)
+    query_weight, key_weight, value_weight = query_key_value_weight.split(
+        (query_heads_per_group, 1, 1), 1
+    )
 
     query_weight = query_weight.reshape(-1, *original_shape[1:])
     key_weight = key_weight.reshape(-1, *original_shape[1:])
@@ -92,7 +100,9 @@ def split_query_key_value_tensor_for_mqa(
     return query_key_value_weight.split((num_heads * head_dim, head_dim, head_dim))
 
 
-def repeat_key_value(x: torch.Tensor, num_heads: int, num_key_value_heads: int) -> torch.Tensor:
+def repeat_key_value(
+    x: torch.Tensor, num_heads: int, num_key_value_heads: int
+) -> torch.Tensor:
     num_groups = num_heads // num_key_value_heads
 
     if num_groups == 1:

--- a/src/instructlab/dolomite/hf_models/modeling_utils/embedding.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/embedding.py
@@ -1,3 +1,4 @@
+# Third Party
 import torch
 import torch.nn as nn
 

--- a/src/instructlab/dolomite/hf_models/modeling_utils/linear.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/linear.py
@@ -1,3 +1,4 @@
+# Third Party
 import torch
 import torch.nn as nn
 

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/__init__.py
@@ -1,8 +1,9 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from .layernorm import get_layernorm
 from .rmsnorm import get_rmsnorm
-
 
 _NORMALIZATION_FUNCTIONS = {
     "layernorm": get_layernorm,
@@ -18,7 +19,11 @@ def get_normalization_function(
 ) -> nn.LayerNorm:
     if name in _NORMALIZATION_FUNCTIONS:
         return _NORMALIZATION_FUNCTIONS[name](
-            normalized_shape, eps=eps, normalization_implementation=normalization_implementation
+            normalized_shape,
+            eps=eps,
+            normalization_implementation=normalization_implementation,
         )
 
-    raise ValueError(f"unexpected `normalization_implementation` {normalization_implementation}")
+    raise ValueError(
+        f"unexpected `normalization_implementation` {normalization_implementation}"
+    )

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/__init__.py
@@ -1,8 +1,9 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from .apex import ApexLayerNorm
 from .apex_persistent import ApexPersistentLayerNorm
-
 
 _LAYERNORM_MODULES = {
     "torch": nn.LayerNorm,
@@ -17,6 +18,10 @@ def get_layernorm(
     normalization_implementation: str = "torch",
 ) -> nn.LayerNorm:
     if normalization_implementation in _LAYERNORM_MODULES:
-        return _LAYERNORM_MODULES[normalization_implementation](normalized_shape=normalized_shape, eps=eps)
+        return _LAYERNORM_MODULES[normalization_implementation](
+            normalized_shape=normalized_shape, eps=eps
+        )
 
-    raise ValueError(f"unexpected `normalization_implementation` {normalization_implementation}")
+    raise ValueError(
+        f"unexpected `normalization_implementation` {normalization_implementation}"
+    )

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/apex.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/apex.py
@@ -1,9 +1,11 @@
+# Third Party
 import torch
 import torch.nn as nn
 
 
 def is_apex_layernorm_available() -> bool:
     try:
+        # Third Party
         from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
 
         return True
@@ -12,14 +14,21 @@ def is_apex_layernorm_available() -> bool:
 
 
 if is_apex_layernorm_available():
+    # Third Party
     from apex.normalization.fused_layer_norm import FusedLayerNormAffineFunction
 
 
 def apex_layernorm(
-    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, eps: float, memory_efficient: bool
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+    memory_efficient: bool,
 ) -> torch.Tensor:
     normalized_shape = (input.shape[-1],)
-    return FusedLayerNormAffineFunction.apply(input, weight, bias, normalized_shape, eps, memory_efficient)
+    return FusedLayerNormAffineFunction.apply(
+        input, weight, bias, normalized_shape, eps, memory_efficient
+    )
 
 
 class ApexLayerNorm(nn.LayerNorm):

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/apex_persistent.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/layernorm/apex_persistent.py
@@ -1,9 +1,11 @@
+# Third Party
 import torch
 import torch.nn as nn
 
 
 def is_apex_persistent_layernorm_available() -> bool:
     try:
+        # Third Party
         from apex.contrib.layer_norm.layer_norm import FastLayerNormFN
 
         return True
@@ -12,6 +14,7 @@ def is_apex_persistent_layernorm_available() -> bool:
 
 
 if is_apex_persistent_layernorm_available():
+    # Third Party
     from apex.contrib.layer_norm.layer_norm import FastLayerNormFN
 
 
@@ -44,7 +47,11 @@ _PERSISTENT_LAYERNORM_ALLOWED_HIDDEN_STATES = [
 
 
 def apex_persistent_layernorm(
-    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, eps: float, memory_efficient
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+    memory_efficient,
 ) -> torch.Tensor:
     return FastLayerNormFN.apply(input, weight, bias, eps, memory_efficient)
 

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/__init__.py
@@ -1,11 +1,17 @@
+# Third Party
 import torch.nn as nn
 
+# Local
 from .apex import ApexRMSNorm
 from .base import RMSNorm
-#from .torchtitan import TorchTitanRMSNorm
+
+# from .torchtitan import TorchTitanRMSNorm
 
 # Removing TorchTitanRMSNorm to avoid unecessary imports and checks
-_RMSNORM_MODULES = {"torch": RMSNorm, "apex": ApexRMSNorm}#, "torchtitan": TorchTitanRMSNorm}
+_RMSNORM_MODULES = {
+    "torch": RMSNorm,
+    "apex": ApexRMSNorm,
+}  # , "torchtitan": TorchTitanRMSNorm}
 
 
 def get_rmsnorm(
@@ -14,6 +20,10 @@ def get_rmsnorm(
     normalization_implementation: str = "torch",
 ) -> nn.LayerNorm:
     if normalization_implementation in _RMSNORM_MODULES:
-        return _RMSNORM_MODULES[normalization_implementation](normalized_shape=normalized_shape, eps=eps)
+        return _RMSNORM_MODULES[normalization_implementation](
+            normalized_shape=normalized_shape, eps=eps
+        )
 
-    raise ValueError(f"unexpected `normalization_implementation` {normalization_implementation}")
+    raise ValueError(
+        f"unexpected `normalization_implementation` {normalization_implementation}"
+    )

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/apex.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/apex.py
@@ -1,10 +1,14 @@
+# Third Party
 import torch
 import torch.nn as nn
 
 
 def is_apex_rmsnorm_available() -> bool:
     try:
-        from apex.normalization.fused_layer_norm import FusedRMSNormAffineMixedDtypesFunction
+        # Third Party
+        from apex.normalization.fused_layer_norm import (
+            FusedRMSNormAffineMixedDtypesFunction,
+        )
 
         return True
     except ImportError:
@@ -12,12 +16,19 @@ def is_apex_rmsnorm_available() -> bool:
 
 
 if is_apex_rmsnorm_available():
-    from apex.normalization.fused_layer_norm import FusedRMSNormAffineMixedDtypesFunction
+    # Third Party
+    from apex.normalization.fused_layer_norm import (
+        FusedRMSNormAffineMixedDtypesFunction,
+    )
 
 
-def apex_rmsnorm(input: torch.Tensor, weight: torch.Tensor, eps: float, memory_efficient: bool) -> torch.Tensor:
+def apex_rmsnorm(
+    input: torch.Tensor, weight: torch.Tensor, eps: float, memory_efficient: bool
+) -> torch.Tensor:
     normalized_shape = (input.shape[-1],)
-    return FusedRMSNormAffineMixedDtypesFunction.apply(input, weight, normalized_shape, eps, memory_efficient)
+    return FusedRMSNormAffineMixedDtypesFunction.apply(
+        input, weight, normalized_shape, eps, memory_efficient
+    )
 
 
 class ApexRMSNorm(nn.RMSNorm):

--- a/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/base.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/normalization/rmsnorm/base.py
@@ -1,3 +1,4 @@
+# Third Party
 import torch
 import torch.nn as nn
 

--- a/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/__init__.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/__init__.py
@@ -1,2 +1,3 @@
+# Local
 from .alibi import Alibi
 from .rope import RoPE, YaRNScaledRoPE, apply_rotary_pos_emb

--- a/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/alibi.py
+++ b/src/instructlab/dolomite/hf_models/modeling_utils/position_embedding/alibi.py
@@ -1,5 +1,7 @@
+# Standard
 import math
 
+# Third Party
 import torch
 import torch.nn as nn
 
@@ -21,24 +23,40 @@ class Alibi(nn.Module):
     ) -> torch.Tensor:
         if attention_mask is None:
             arange_tensor = (
-                torch.arange(key_length, device=device).unsqueeze(0).unsqueeze(0).expand(batch_size, -1, -1)
+                torch.arange(key_length, device=device)
+                .unsqueeze(0)
+                .unsqueeze(0)
+                .expand(batch_size, -1, -1)
             )
         else:
-            arange_tensor = (attention_mask.cumsum(dim=-1) - 1).masked_fill_(attention_mask == 0, 0).unsqueeze(1)
+            arange_tensor = (
+                (attention_mask.cumsum(dim=-1) - 1)
+                .masked_fill_(attention_mask == 0, 0)
+                .unsqueeze(1)
+            )
 
         alibi = self.slopes.unsqueeze(1) * arange_tensor
         return alibi.to(dtype)
 
     def reset_parameters(self) -> None:
         closest_power_of_2 = 2 ** math.floor(math.log2(self.num_heads))
-        base = torch.tensor(2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))), dtype=torch.float32)
+        base = torch.tensor(
+            2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))), dtype=torch.float32
+        )
         powers = torch.arange(1, 1 + closest_power_of_2, dtype=torch.int32)
         slopes = torch.pow(base, powers)
 
         if closest_power_of_2 != self.num_heads:
-            extra_base = torch.tensor(2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))), dtype=torch.float32)
-            num_remaining_heads = min(closest_power_of_2, self.num_heads - closest_power_of_2)
-            extra_powers = torch.arange(1, 1 + 2 * num_remaining_heads, 2, dtype=torch.int32)
+            extra_base = torch.tensor(
+                2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))),
+                dtype=torch.float32,
+            )
+            num_remaining_heads = min(
+                closest_power_of_2, self.num_heads - closest_power_of_2
+            )
+            extra_powers = torch.arange(
+                1, 1 + 2 * num_remaining_heads, 2, dtype=torch.int32
+            )
             slopes = torch.cat([slopes, torch.pow(extra_base, extra_powers)], dim=0)
 
         self.register_buffer("slopes", slopes, persistent=False)

--- a/src/instructlab/dolomite/hf_models/models/__init__.py
+++ b/src/instructlab/dolomite/hf_models/models/__init__.py
@@ -2,4 +2,4 @@
 # Extracted from https://github.com/ibm-granite/dolomite-engine
 # ----------------------------------------------------------------
 # Local
-from .gpt_dolomite import GPTDolomiteForCausalLM, GPTDolomiteModel, GPTDolomiteConfig
+from .gpt_dolomite import GPTDolomiteConfig, GPTDolomiteForCausalLM, GPTDolomiteModel

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/__init__.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/__init__.py
@@ -1,3 +1,4 @@
+# Local
 from .base import GPTDolomiteModel, GPTDolomitePreTrainedModel
 from .config import GPTDolomiteConfig
 from .main import GPTDolomiteForCausalLM

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/base.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/base.py
@@ -1,3 +1,4 @@
+# Local
 from ...mixins import BaseModelMixin, PreTrainedModelMixin
 from .config import GPTDolomiteConfig
 from .layer import GPTDolomiteBlock

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/config.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/config.py
@@ -1,3 +1,4 @@
+# Local
 from ...config import CommonConfig
 
 

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/layer.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/layer.py
@@ -1,7 +1,9 @@
+# Third Party
+from transformers import DynamicCache
 import torch
 import torch.nn as nn
-from transformers import DynamicCache
 
+# Local
 from ...enums import AttentionHeadType
 from ...modeling_utils import get_attention_module, get_normalization_function
 from .config import GPTDolomiteConfig
@@ -36,7 +38,11 @@ class GPTDolomiteBlock(nn.Module):
             normalization_implementation=normalization_implementation,
         )
         self.attn = get_attention_module(
-            config, True, attention_implementation, use_padding_free_transformer, layer_idx
+            config,
+            True,
+            attention_implementation,
+            use_padding_free_transformer,
+            layer_idx,
         )
         self.ln_2 = get_normalization_function(
             config.normalization_function,

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/main.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/main.py
@@ -1,3 +1,4 @@
+# Local
 from ...mixins import CausalLMModelMixin
 from .base import GPTDolomiteModel, GPTDolomitePreTrainedModel
 

--- a/src/instructlab/dolomite/hf_models/models/gpt_dolomite/mlp.py
+++ b/src/instructlab/dolomite/hf_models/models/gpt_dolomite/mlp.py
@@ -1,8 +1,11 @@
+# Standard
 import math
 
+# Third Party
 import torch
 import torch.nn as nn
 
+# Local
 from ...enums import InitMethod
 from ...modeling_utils import ParameterizedLinear, get_activation_function, is_glu
 from .config import GPTDolomiteConfig
@@ -38,9 +41,13 @@ class MLP(nn.Module):
         std = initializer_range / math.sqrt(2 * n_layer)
         if init_method == InitMethod.mup:
             std /= math.sqrt(m_width)
-        self.c_proj = ParameterizedLinear(intermediate_size, hidden_size, bias=add_bias, std=std)
+        self.c_proj = ParameterizedLinear(
+            intermediate_size, hidden_size, bias=add_bias, std=std
+        )
 
-        self.dropout = nn.Identity() if residual_dropout == 0 else nn.Dropout(residual_dropout)
+        self.dropout = (
+            nn.Identity() if residual_dropout == 0 else nn.Dropout(residual_dropout)
+        )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = self.c_fc(hidden_states)
@@ -50,9 +57,13 @@ class MLP(nn.Module):
         return hidden_states
 
 
-def interleave_up_gate_tensor_for_mlp(up_weight: torch.Tensor, gate_weight: torch.Tensor) -> torch.Tensor:
+def interleave_up_gate_tensor_for_mlp(
+    up_weight: torch.Tensor, gate_weight: torch.Tensor
+) -> torch.Tensor:
     return torch.cat([up_weight, gate_weight])
 
 
-def split_up_gate_tensor_for_mlp(c_fc_weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+def split_up_gate_tensor_for_mlp(
+    c_fc_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
     return c_fc_weight.chunk(2)

--- a/src/instructlab/dolomite/hf_models/register_hf.py
+++ b/src/instructlab/dolomite/hf_models/register_hf.py
@@ -1,11 +1,13 @@
-from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM
-
-from .models import (
-    GPTDolomiteConfig,
-    GPTDolomiteForCausalLM,
-    GPTDolomiteModel,
+# Third Party
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
 )
 
+# Local
+from .models import GPTDolomiteConfig, GPTDolomiteForCausalLM, GPTDolomiteModel
 
 # (AutoConfig, AutoModel, AutoModelForCausalLM)
 _CUSTOM_MODEL_REGISTRY = [
@@ -16,7 +18,11 @@ _CUSTOM_MODEL_CLASSES = []
 
 
 def register_model_classes() -> None:
-    for config_class, auto_model_class, auto_model_for_causal_lm_class in _CUSTOM_MODEL_REGISTRY:
+    for (
+        config_class,
+        auto_model_class,
+        auto_model_for_causal_lm_class,
+    ) in _CUSTOM_MODEL_REGISTRY:
         model_type = config_class.model_type
 
         AutoConfig.register(model_type, config_class)
@@ -27,5 +33,11 @@ def register_model_classes() -> None:
         _CUSTOM_MODEL_CLASSES.append(auto_model_for_causal_lm_class)
 
 
-def is_custom_model(model_class: type[AutoModelForCausalLM] | type[AutoModelForSeq2SeqLM], model_type: str) -> bool:
-    return model_class.__name__ in _CUSTOM_MODEL_CLASSES or model_type in _CUSTOM_MODEL_TYPES
+def is_custom_model(
+    model_class: type[AutoModelForCausalLM] | type[AutoModelForSeq2SeqLM],
+    model_type: str,
+) -> bool:
+    return (
+        model_class.__name__ in _CUSTOM_MODEL_CLASSES
+        or model_type in _CUSTOM_MODEL_TYPES
+    )

--- a/src/instructlab/dolomite/hf_models/utils.py
+++ b/src/instructlab/dolomite/hf_models/utils.py
@@ -1,3 +1,4 @@
+# Third Party
 import torch
 
 
@@ -25,13 +26,18 @@ def convert_padding_free_lists_to_tensors(
     labels: list[list[int]] | None = None,
     device: torch.device = None,
 ) -> tuple[torch.Tensor]:
-
     # check input types are correct
     error_message = "{variable} should be of type List[List[{dtype}]]"
     _check_list_type(input_ids, error_message.format(variable="input_ids", dtype="int"))
-    _check_list_type(inputs_embeds, error_message.format(variable="inputs_embeds", dtype="float"))
-    _check_list_type(position_ids, error_message.format(variable="position_ids", dtype="int"))
-    _check_list_type(token_type_ids, error_message.format(variable="token_type_ids", dtype="int"))
+    _check_list_type(
+        inputs_embeds, error_message.format(variable="inputs_embeds", dtype="float")
+    )
+    _check_list_type(
+        position_ids, error_message.format(variable="position_ids", dtype="int")
+    )
+    _check_list_type(
+        token_type_ids, error_message.format(variable="token_type_ids", dtype="int")
+    )
     _check_list_type(labels, error_message.format(variable="labels", dtype="int"))
 
     # prepare inputs for the model
@@ -57,7 +63,9 @@ def convert_padding_free_lists_to_tensors(
     return input_ids, position_ids, token_type_ids, labels, cu_seqlens, max_seqlen
 
 
-def _check_list_type(list_of_list: list[list[int | float]] | None, error_message: str) -> None:
+def _check_list_type(
+    list_of_list: list[list[int | float]] | None, error_message: str
+) -> None:
     if list_of_list is None:
         return
 

--- a/src/instructlab/dolomite/utils/hf_hub.py
+++ b/src/instructlab/dolomite/utils/hf_hub.py
@@ -1,11 +1,15 @@
+# Standard
 import os
 
+# Third Party
 from transformers import AutoConfig, AutoTokenizer
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME, cached_file
 from transformers.utils.hub import get_checkpoint_shard_files
 
 
-def download_repo(repo_name_or_path: str) -> tuple[AutoConfig | None, AutoTokenizer | None, str]:
+def download_repo(
+    repo_name_or_path: str,
+) -> tuple[AutoConfig | None, AutoTokenizer | None, str]:
     config = _download_config(repo_name_or_path)
     tokenizer = _download_tokenizer(repo_name_or_path)
     model_path = None
@@ -20,7 +24,9 @@ def download_repo(repo_name_or_path: str) -> tuple[AutoConfig | None, AutoTokeni
         except:
             # try downloading model weights if they are sharded
             try:
-                sharded_filename = cached_file(repo_name_or_path, SAFE_WEIGHTS_INDEX_NAME)
+                sharded_filename = cached_file(
+                    repo_name_or_path, SAFE_WEIGHTS_INDEX_NAME
+                )
                 get_checkpoint_shard_files(repo_name_or_path, sharded_filename)
                 model_path = os.path.dirname(sharded_filename)
             except:

--- a/src/instructlab/dolomite/utils/safetensors.py
+++ b/src/instructlab/dolomite/utils/safetensors.py
@@ -1,11 +1,13 @@
+# Standard
 import json
 import os
 
-import torch
+# Third Party
 from huggingface_hub import split_torch_state_dict_into_shards
 from safetensors import safe_open
 from safetensors.torch import save_file
 from transformers.modeling_utils import SAFE_WEIGHTS_INDEX_NAME
+import torch
 
 
 class SafeTensorsWeightsManager:
@@ -33,7 +35,10 @@ class SafeTensorsWeightsManager:
         return f.get_slice(tensor_name)
 
     def get_tensor(
-        self, tensor_name: str, dtype: torch.dtype | None = None, device: torch.device | None = None
+        self,
+        tensor_name: str,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
         filename = self.tensor_filenames[tensor_name]
         f = self.file_handles[filename]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 # py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
+# py312-unit runs the same tests with 'python3.12'
 envlist = ruff, lint, mypy, spellcheck
 minversion = 4.4
 


### PR DESCRIPTION
Now that PyTorch 2.4 supports Python 3.12, This change attempts updating the default Python version to 3.12. It also brings the update to PyTorch 2.4.1 and all its dependencies.