### PR TITLE
chore: Switch to python 3.12 for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ on:
       - '.github/**'
 
 env:
-  PYTHON_VERSION: 3.11
+  PYTHON_VERSION: 3.12
 
 jobs:
   lint:
@@ -45,10 +45,10 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml

--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.9
+py-version=3.10
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tox]
-# py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
 envlist = ruff, lint, mypy, spellcheck
 minversion = 4.4
 


### PR DESCRIPTION
- **chore: Use python 3.12 in lint checks**
- **chore: bump target python version for ruff and pylint to 3.11**
